### PR TITLE
Update PdfViewerEntry.php

### DIFF
--- a/src/Infolists/Components/PdfViewerEntry.php
+++ b/src/Infolists/Components/PdfViewerEntry.php
@@ -53,7 +53,7 @@ class PdfViewerEntry extends ViewEntry
         return $this;
     }
 
-    public function getFileUrl(?string $state = null): string
+    public function getFileUrl(?string $state = null): string|null
     {
         if (empty($state)) {
             return $this->evaluate($this->fileUrl);


### PR DESCRIPTION
Fix: Allow getFileUrl to return null when no file is available

- Updated the getFileUrl method to handle cases where a file URL might not exist.
- Changed the return type to `string|null` for better flexibility and to prevent type errors when null is returned.