### PR TITLE
Autofix: [Bug]: Joaopaulolndev\FilamentPdfViewer\Forms\Components\PdfViewerField::getFileUrl(): Return value must be of type string, null returned

### DIFF
--- a/resources/views/filament/components/forms/pdf-viewer-field.blade.php
+++ b/resources/views/filament/components/forms/pdf-viewer-field.blade.php
@@ -25,13 +25,13 @@
                 ->class(['fi-fo-textarea overflow-hidden'])
         "
     >
+        @if(!empty($getState()) && $getRoute(current($getState())))
         @if(!empty($getState()))
-            <iframe
                 class="w-full"
                 src="{{ $getRoute(current($getState())) }}" style="min-height: {{ $getMinHeight() }};">
             </iframe>
+        @elseif(!empty($getFileUrl()) && $getFileUrl() !== '')
         @elseif(!empty($getFileUrl()))
-            <iframe
                 class="w-full"
                 src="{{ $getFileUrl() }}" style="min-height: {{ $getMinHeight() }};">
             </iframe>

--- a/src/Forms/Components/PdfViewerField.php
+++ b/src/Forms/Components/PdfViewerField.php
@@ -68,9 +68,12 @@ class PdfViewerField extends ViewField
     }
 
     public function getFileUrl(?string $state = null): string
+    public function getFileUrl(?string $state = null): string
+    {
     {
         if (empty($state)) {
-            return $this->evaluate($this->fileUrl);
+            return $this->evaluate($this->fileUrl) ?: '';
+        if (empty($state)) {
         }
 
         if ((filter_var($state, FILTER_VALIDATE_URL) !== false) || str($state)->startsWith('data:')) {
@@ -83,11 +86,11 @@ class PdfViewerField extends ViewField
         if ($this->shouldCheckFileExistence()) {
             try {
                 if (! $storage->exists($state)) {
+                    return '';
                     return null;
-                }
             } catch (UnableToCheckFileExistence $exception) {
+                return '';
                 return null;
-            }
         }
 
         if ($this->getVisibility() === 'private') {
@@ -101,8 +104,8 @@ class PdfViewerField extends ViewField
             }
         }
 
+        return $storage->url($state) ?: '';
         return $storage->url($state);
-    }
 
     public function getVisibility(): string
     {


### PR DESCRIPTION
Modified the PdfViewerField class to handle null state values and prevent errors when uploading new files after removing the existing one. Updated the getFileUrl method to return an empty string instead of null when the state is empty. 
> [!CAUTION]
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!
>
> The fix provided by Latta AI might not be complete and it can serve as an inspiration.

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission

If you no longer want Latta AI to attempt fixing issues on your repository, you can block this account.
    