### PR TITLE
Addition of Disk & Visibility methods to PDFViewerEntry

### DIFF
--- a/src/Infolists/Components/PdfViewerEntry.php
+++ b/src/Infolists/Components/PdfViewerEntry.php
@@ -36,6 +36,13 @@ class PdfViewerEntry extends ViewEntry
         return $this->minHeight;
     }
 
+    public function disk(string|closure $disk): self
+    {
+        $this->disk = $disk;
+
+        return $this;
+    }
+
     public function getDisk(): Filesystem
     {
         return Storage::disk($this->getDiskName());
@@ -90,10 +97,12 @@ class PdfViewerEntry extends ViewEntry
         return $storage->url($state);
     }
 
-    // public function getFileUrl(): string
-    // {
-    //     return $this->evaluate($this->fileUrl);
-    // }
+    public function visibility(string|closure $visibility): self
+    {
+        $this->visibility = $visibility;
+
+        return $this;
+    }
 
     public function getVisibility(): string
     {


### PR DESCRIPTION
I have added in the methods to allow for the setting of the disk & visibillity properties in the PDFViewerEntry to allow for the accessing of PDFs from alternative disks and using temp urls as reported in #19 